### PR TITLE
[BE-01] Add `cooking_time` to recipes & return it in response.

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -7,7 +7,7 @@ module Api
       end
 
       def show
-        render json: RecipeSerializer.new(@recipe).to_h
+        render json: RecipeShowSerializer.new(@recipe).to_h
       end
 
       def create

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -38,7 +38,7 @@ module Api
       private
 
       def recipe_params
-        params.require(:recipe).permit(%i[name content])
+        params.require(:recipe).permit(%i[name content cooking_time])
       end
 
       def set_recipe

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,4 @@
 class Recipe < ApplicationRecord
   validates :name, presence: true
+  validates :cooking_time, numericality: { only_integer: true, greater_than: 0}
 end

--- a/app/serializers/recipe_show_serializer.rb
+++ b/app/serializers/recipe_show_serializer.rb
@@ -1,3 +1,3 @@
 class RecipeShowSerializer < RecipeSerializer
-  atributes  :cookie_time
+  attributes :cooking_time
 end

--- a/app/serializers/recipe_show_serializer.rb
+++ b/app/serializers/recipe_show_serializer.rb
@@ -1,0 +1,3 @@
+class RecipeShowSerializer < RecipeSerializer
+  atributes  :cookie_time
+end

--- a/db/migrate/20220714085653_add_cooking_time_to_recipes.rb
+++ b/db/migrate/20220714085653_add_cooking_time_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddCookingTimeToRecipes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :recipes, :cooking_time, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_095518) do
+ActiveRecord::Schema.define(version: 2022_07_14_085653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_095518) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "cooking_time"
   end
 
 end

--- a/skrypt.sh
+++ b/skrypt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+IP_ADDR=`/sbin/ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}'`
+
+echo "Twoj publiczny adres ip to: "
+curl http://169.254.169.254/latest/meta-data/public-ipv4 
+echo ""
+rails s -b $IP_ADDR -p 8082

--- a/spec/controllers/api/v1/recipes_controller_spec.rb
+++ b/spec/controllers/api/v1/recipes_controller_spec.rb
@@ -14,7 +14,8 @@ describe Api::V1::RecipesController do
 
   describe '[GET] #show' do
     let!(:recipe) { create(:recipe) }
-    let(:expected_response) { RecipeSerializer.new(recipe).to_json }
+    let(:expected_response) { RecipeShowSerializer.new(recipe).to_json }
+
     before do
       get :show, params: { id: recipe.to_param }
     end

--- a/spec/controllers/api/v1/recipes_controller_spec.rb
+++ b/spec/controllers/api/v1/recipes_controller_spec.rb
@@ -30,7 +30,8 @@ describe Api::V1::RecipesController do
       {
         recipe: {
           name: 'Leczo',
-          content: 'Very good dish'
+          content: 'Very good dish',
+          cooking_time: 20
         }
       }
     end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :recipe do
     name { Faker::Food.dish }
     content { Faker::Food.description }
+    cooking_time { Faker::Number.number(digits: 2) }
   end
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -4,5 +4,9 @@ RSpec.describe Recipe, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
   end
+  describe 'check if cooking_time is integer and >0' do
+    it { is_expected.to validate_numericality_of(:cooking_time).only_integer.is_greater_than(0) }
+  # it {expect(:cooking_time).to be_a_kind_of(Integer)}
+  end
   
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe Recipe, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
   end
+  
 end

--- a/spec/serializers/recipe_show_serializer_spec.rb
+++ b/spec/serializers/recipe_show_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+UNKNOWN = "unknown"
+describe RecipeShowSerializer do
+  
+def cooking_time
+  return UNKNOWN unless object.cooking_time
+
+  object.cooking_time
+end
+end


### PR DESCRIPTION
https://trello.com/c/yMNSnbLO/1-be-01-add-cookingtime-to-recipes-return-it-in-response-l


Add cooking_time field to recipes model, add validation & response.

AC:
1. Cooking_time field may be set during create or update a record
2. Cooking_time field is returned in #show response.
3. Cooking_time field has a validation for checking unrealistic cases
4. Cooking field returns ‘unknow’ if value is empty.